### PR TITLE
fixed typo gendents -> getdents

### DIFF
--- a/ps4.html
+++ b/ps4.html
@@ -991,7 +991,7 @@ logAdd(hexDump(moduleInfoAddress, 0x1a8));</code></pre>
 				</p>
 				
 				<p>
-					I'm not sure why this is, but if we use <code>gendents</code> instead of <code>read</code> for directories, it will work much more reliably:
+					I'm not sure why this is, but if we use <code>getdents</code> instead of <code>read</code> for directories, it will work much more reliably:
 				</p>
 				
 				<pre><code>writeString(chain.data, "/dev/");


### PR DESCRIPTION
When I was reading, I spent an embarrassing few minutes Googling "gendents bsd" and being confused when I realized it was just a typo and it was spelled correctly in the JavaScript a few lines later.
