### PR TITLE
Broken Link Fix

### DIFF
--- a/DS-exploit-finding.html
+++ b/DS-exploit-finding.html
@@ -48,7 +48,7 @@
 				<p>You will need an ARM compiler; I will be using devkitARM from <a href="http://devkitpro.org/">devkitPro</a>.</p>
 				<p>You will need a DS emulator; I recommend using <a href="http://desmume.org/">DeSmuME</a> however I have heard that <a href="http://problemkaputt.de/gba.htm">NO$GBA</a> also has excellent debugging tools.</p>
 				<p>You will need a hex editor to edit save files; I will be using <a href="http://www.hhdsoftware.com/free-hex-editor">Hex Editor Neo</a>.</p>
-				<p>I will also be using <a href="www.cjmweb.net/vbindiff/">VBinDiff</a> which isn't necessary but helps to identify the location of checksums within a save file.</p>
+				<p>I will also be using <a href="https://www.cjmweb.net/vbindiff/">VBinDiff</a> which isn't necessary but helps to identify the location of checksums within a save file.</p>
 				<br>
 				
 				<h2 id="what-is-a-buffer-overflow">What is a buffer overflow?</h2>


### PR DESCRIPTION
The current link resolves to
'https://cturt.github.io/www.cjmweb.net/vbindiff/' instead to
'www.cjmweb.net/vbindiff'
